### PR TITLE
Updated endpoints to work with MongoDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ typings/
 
 # DynamoDB Local files
 .dynamodb/
+
+# vscode settings
+.vscode

--- a/index.js
+++ b/index.js
@@ -35,7 +35,6 @@ connection.once('open', () => {
         } else {
           console.log("mongodb: Successfully added collection");
         }
-        mongoose.connection.close();
       });
     });
 });

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 const app = require('./src/app');
 const mongoose = require('mongoose');
+const JobModel = require('./src/models/jobs.model.js');
+const jobs = require('./src/jobs.json')
 
 require('dotenv').config();
 
@@ -16,6 +18,26 @@ const connection = mongoose.connection;
 
 connection.once('open', () => {
     console.log("MongoDB connection established");
+    connection.db.listCollections({name: 'jobs'})
+    .next((err, collinfo) => {
+      if (collinfo) {
+        // if exists
+        JobModel.collection.drop();
+        console.log('mongodb: Collection dropped');
+      } else {
+        console.log('mongodb: Collection does not exist');
+      } 
+
+      console.log('mongodb: Updating collection...');
+      JobModel.collection.insertMany(jobs[0], (err, res) => {
+        if (err) {
+          console.log(err);
+        } else {
+          console.log("mongodb: Successfully added collection");
+        }
+        mongoose.connection.close();
+      });
+    });
 });
 
 app.listen(PORT, () => {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node index.js",
     "dev": "nodemon index.js",
-    "dbfetch": "gsjson 1V-eQTG1UNTDnG-lrGwd_Iby5rwLZlpZ0nxpuhobp_r4 src/jobs.json -ab --hash jobQueryString"
+    "dbfetch": "gsjson 1V-eQTG1UNTDnG-lrGwd_Iby5rwLZlpZ0nxpuhobp_r4 src/jobs.json -ab"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node index.js",
     "dev": "nodemon index.js",
-    "dbupdate": "gsjson 1V-eQTG1UNTDnG-lrGwd_Iby5rwLZlpZ0nxpuhobp_r4 src/jobs.json -ab --hash jobQueryString"
+    "dbfetch": "gsjson 1V-eQTG1UNTDnG-lrGwd_Iby5rwLZlpZ0nxpuhobp_r4 src/jobs.json -ab --hash jobQueryString"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/src/app.js
+++ b/src/app.js
@@ -1,9 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const rateLimit = require('express-rate-limit');
-const mongoose = require('mongoose');
 
-const jobs = require('./jobs');
 const JobModel = require('./models/jobs.model');
 
 const app = express();
@@ -21,7 +19,7 @@ app.get('/', (_, res) => {
  * Jobs endpoint
  * Query for specific job names
  */
-app.get('/beta/jobs', (req, res) => {
+app.get('/beta/jobs', (req, res, next) => {
   const { query: { name } } = req; // name specific query
 
   if (name) {
@@ -42,7 +40,7 @@ app.get('/beta/jobs', (req, res) => {
   } else {
     JobModel.find().then(job => {
       res.status(200).json(job);
-    }).catch(err => res.status(400).json('Error: ' + err));
+    }).catch(next);
   }
 });
 
@@ -51,7 +49,7 @@ app.get('/beta/jobs', (req, res) => {
  * Query for specific job names given a type
  * Valid types: [Warrior, Mage, Ranger, Monk, Sarah, Meia, Graff, Sophie, Skin, Legend, Ex]
  */
-app.get('/beta/jobs/type', (req, res) => {
+app.get('/beta/jobs/type', (req, res, next) => {
   const { query: { type } } = req; // type specific query
 
   if (!type) {
@@ -64,11 +62,11 @@ app.get('/beta/jobs/type', (req, res) => {
     let property = "jobIs" + `${type}`;
     JobModel.find().exists(property, true).then(jobs => {
       res.status(200).json(jobs);
-    }).catch(err => res.status(400).json('Error: ' + err));
+    }).catch(next);
   } else {
     JobModel.find().where({ jobType: type }).then(jobs => {
       res.status(200).json(jobs);
-    }).catch(err => res.status(400).json('Error: ' + err));
+    }).catch(next);
   }
 });
 
@@ -76,12 +74,12 @@ app.get('/beta/jobs/type', (req, res) => {
  * Jobs endpoint
  * Returns list of queryable jobs 
  */
-app.get('/beta/jobs/keys', (_, res) => {
+app.get('/beta/jobs/keys', (_, res, next) => {
   JobModel.find().distinct('jobQueryString')
     .then(jobs => {
       res.status(200).json(jobs);
     })
-    .catch(err => res.status(400).json('Error: ' + err));
+    .catch(next);
 });
 
 // catch-all error handler

--- a/src/app.js
+++ b/src/app.js
@@ -74,10 +74,14 @@ app.get('/beta/jobs/type', (req, res) => {
 
 /**
  * Jobs endpoint
- * Returns list of job keys
+ * Returns list of queryable jobs 
  */
 app.get('/beta/jobs/keys', (_, res) => {
-  return res.status(200).json(Object.keys(jobs[0]));
+  JobModel.find().distinct('jobQueryString')
+    .then(jobs => {
+      res.status(200).json(jobs);
+    })
+    .catch(err => res.status(400).json('Error: ' + err));
 });
 
 // catch-all error handler

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const rateLimit = require('express-rate-limit');
+const mongoose = require('mongoose');
 
 const jobs = require('./jobs');
 const Job = require('./models/jobs.model');
@@ -14,44 +15,6 @@ app.get('/', (_, res) => {
   return res
     .status(200)
     .send('<img src="https://cdn.discordapp.com/emojis/404433244113862667.png?v=1" />');
-});
-
-
-app.post('/beta/jobs/add', (req, res) => {
-    const jobId = jobs[0]["onion-knight"].jobId;
-    const jobQueryString = jobs[0]["onion-knight"].jobQueryString;
-    const jobType = jobs[0]["onion-knight"].jobType;
-    const jobName = jobs[0]["onion-knight"].jobName;
-    const jobStat = {
-        Hp: jobs[0]["onion-knight"].jobStatHp,
-        Attack: jobs[0]["onion-knight"].jobStatAttack,
-        Break: jobs[0]["onion-knight"].jobStatBreak,
-        Magic: jobs[0]["onion-knight"].jobStatMagic,
-        CritChance: jobs[0]["onion-knight"].jobStatCritChance,
-        Speed: jobs[0]["onion-knight"].jobStatSpeed,
-        Defense: jobs[0]["onion-knight"].jobStatDefense,
-    };
-    const jobOrbs = {
-        Set1: [jobs[0]["onion-knight"].jobOrbSet1]
-    };
-    const jobMpRole = jobs[0]["onion-knight"].jobMpRole;
-    const jobUrlIcon = jobs[0]["onion-knight"].jobUrlIcon;
-
-    const newJob = new Job({
-      jobId,
-      jobQueryString,
-      jobType,
-      jobName,
-      jobStat,
-      jobOrbs,
-      jobMpRole,
-      jobUrlIcon
-    });
-
-    // save to db
-    newJob.save()
-      .then(() => res.json('Job added!'))
-      .catch(err => res.status(400).json('Error: ' + err));
 });
 
 /**

--- a/src/app.js
+++ b/src/app.js
@@ -3,6 +3,7 @@ const cors = require('cors');
 const rateLimit = require('express-rate-limit');
 
 const jobs = require('./jobs');
+const Job = require('./models/jobs.model');
 
 const app = express();
 app.enable('trust proxy');
@@ -13,6 +14,44 @@ app.get('/', (_, res) => {
   return res
     .status(200)
     .send('<img src="https://cdn.discordapp.com/emojis/404433244113862667.png?v=1" />');
+});
+
+
+app.post('/beta/jobs/add', (req, res) => {
+    const jobId = jobs[0]["onion-knight"].jobId;
+    const jobQueryString = jobs[0]["onion-knight"].jobQueryString;
+    const jobType = jobs[0]["onion-knight"].jobType;
+    const jobName = jobs[0]["onion-knight"].jobName;
+    const jobStat = {
+        Hp: jobs[0]["onion-knight"].jobStatHp,
+        Attack: jobs[0]["onion-knight"].jobStatAttack,
+        Break: jobs[0]["onion-knight"].jobStatBreak,
+        Magic: jobs[0]["onion-knight"].jobStatMagic,
+        CritChance: jobs[0]["onion-knight"].jobStatCritChance,
+        Speed: jobs[0]["onion-knight"].jobStatSpeed,
+        Defense: jobs[0]["onion-knight"].jobStatDefense,
+    };
+    const jobOrbs = {
+        Set1: [jobs[0]["onion-knight"].jobOrbSet1]
+    };
+    const jobMpRole = jobs[0]["onion-knight"].jobMpRole;
+    const jobUrlIcon = jobs[0]["onion-knight"].jobUrlIcon;
+
+    const newJob = new Job({
+      jobId,
+      jobQueryString,
+      jobType,
+      jobName,
+      jobStat,
+      jobOrbs,
+      jobMpRole,
+      jobUrlIcon
+    });
+
+    // save to db
+    newJob.save()
+      .then(() => res.json('Job added!'))
+      .catch(err => res.status(400).json('Error: ' + err));
 });
 
 /**

--- a/src/app.js
+++ b/src/app.js
@@ -39,11 +39,11 @@ app.get('/beta/jobs', (req, res) => {
 
       return res.status(200).json(job);
     });
+  } else {
+    JobModel.find().then(job => {
+      res.status(200).json(job);
+    }).catch(err => res.status(400).json('Error: ' + err));
   }
-
-  JobModel.find().then(job => {
-    res.status(200).json(job);
-  }).catch(err => res.status(400).json('Error: ' + err));
 });
 
 /**
@@ -53,27 +53,23 @@ app.get('/beta/jobs', (req, res) => {
  */
 app.get('/beta/jobs/type', (req, res) => {
   const { query: { type } } = req; // type specific query
-  let jobsOfType = {};
 
   if (!type) {
-    let err = new Error("input valid query string");
+    let err = new Error("Query string required");
     const { message } = err;
     return res.status(err.status || 500).json({ message });
   }
 
-  for(job in jobs[0]) { 
-    if(jobs[0][job].jobType === type) {
-      jobsOfType[job] = jobs[0][job];
-    }  
-
-    if (type === "Skin" && jobs[0][job].hasOwnProperty('jobIsSkin') 
-        || type === "Legend" && jobs[0][job].hasOwnProperty('jobIsLegend')
-        || type === "Ex" && jobs[0][job].hasOwnProperty('jobIsEx')) {
-          jobsOfType[job] = jobs[0][job];
-    }
+  if (type === "Skin" || type === "Legend" || type === "Ex") {
+    let property = "jobIs" + `${type}`;
+    JobModel.find().exists(property, true).then(jobs => {
+      res.status(200).json(jobs);
+    }).catch(err => res.status(400).json('Error: ' + err));
+  } else {
+    JobModel.find().where({ jobType: type }).then(jobs => {
+      res.status(200).json(jobs);
+    }).catch(err => res.status(400).json('Error: ' + err));
   }
-
-  return res.status(200).json(jobsOfType || {});
 });
 
 /**

--- a/src/jobs.json
+++ b/src/jobs.json
@@ -1,7 +1,7 @@
 [
     [
         {
-            "_id": "1-onion-knight",
+            "_id": "1",
             "jobQueryString": "onion-knight",
             "jobType": "Warrior",
             "jobName": "Onion Knight",
@@ -18,7 +18,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "2-apprentice-mage",
+            "_id": "2",
             "jobQueryString": "apprentice-mage",
             "jobType": "Mage",
             "jobName": "Apprentice Mage",
@@ -34,7 +34,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "3-neophyte-ranger",
+            "_id": "3",
             "jobQueryString": "neophyte-ranger",
             "jobType": "Ranger",
             "jobName": "Neophyte Ranger",
@@ -50,7 +50,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "4-trainee-monk",
+            "_id": "4",
             "jobQueryString": "trainee-monk",
             "jobType": "Monk",
             "jobName": "Trainee Monk",
@@ -65,7 +65,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
         {
-            "_id": "5-the-azure-witch",
+            "_id": "5",
             "jobQueryString": "the-azure-witch",
             "jobType": "Meia",
             "jobName": "The Azure Witch",
@@ -82,7 +82,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "6-battle-princess",
+            "_id": "6",
             "jobQueryString": "battle-princess",
             "jobType": "Sarah",
             "jobName": "Battle Princess",
@@ -98,7 +98,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "7-freelancer",
+            "_id": "7",
             "jobQueryString": "freelancer",
             "jobType": "Sophie",
             "jobName": "Freelancer",
@@ -115,7 +115,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
         {
-            "_id": "8-epeiste",
+            "_id": "8",
             "jobQueryString": "epeiste",
             "jobType": "Graff",
             "jobName": "Epeiste",
@@ -132,7 +132,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "9-warrior",
+            "_id": "9",
             "jobQueryString": "warrior",
             "jobType": "Warrior",
             "jobName": "Warrior",
@@ -147,7 +147,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "10-knight",
+            "_id": "10",
             "jobQueryString": "knight",
             "jobType": "Warrior",
             "jobName": "Knight",
@@ -162,7 +162,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "11-mage",
+            "_id": "11",
             "jobQueryString": "mage",
             "jobType": "Mage",
             "jobName": "Mage",
@@ -177,7 +177,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "12-white-mage",
+            "_id": "12",
             "jobQueryString": "white-mage",
             "jobType": "Mage",
             "jobName": "White Mage",
@@ -192,7 +192,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "13-ranger",
+            "_id": "13",
             "jobQueryString": "ranger",
             "jobType": "Ranger",
             "jobName": "Ranger",
@@ -207,7 +207,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "14-hunter",
+            "_id": "14",
             "jobQueryString": "hunter",
             "jobType": "Ranger",
             "jobName": "Hunter",
@@ -222,7 +222,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "15-dark-knight",
+            "_id": "15",
             "jobQueryString": "dark-knight",
             "jobType": "Warrior",
             "jobName": "Dark Knight",
@@ -237,7 +237,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "16-black-mage",
+            "_id": "16",
             "jobQueryString": "black-mage",
             "jobType": "Mage",
             "jobName": "Black Mage",
@@ -252,7 +252,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "17-thief",
+            "_id": "17",
             "jobQueryString": "thief",
             "jobType": "Ranger",
             "jobName": "Thief",
@@ -267,7 +267,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "18-samurai",
+            "_id": "18",
             "jobQueryString": "samurai",
             "jobType": "Warrior",
             "jobName": "Samurai",
@@ -282,7 +282,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "19-red-mage",
+            "_id": "19",
             "jobQueryString": "red-mage",
             "jobType": "Mage",
             "jobName": "Red Mage",
@@ -297,7 +297,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "20-assassin",
+            "_id": "20",
             "jobQueryString": "assassin",
             "jobType": "Ranger",
             "jobName": "Assassin",
@@ -312,7 +312,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "21-dragoon",
+            "_id": "21",
             "jobQueryString": "dragoon",
             "jobType": "Warrior",
             "jobName": "Dragoon",
@@ -327,7 +327,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "22-scholar",
+            "_id": "22",
             "jobQueryString": "scholar",
             "jobType": "Mage",
             "jobName": "Scholar",
@@ -342,7 +342,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "23-dancer",
+            "_id": "23",
             "jobQueryString": "dancer",
             "jobType": "Ranger",
             "jobName": "Dancer",
@@ -357,7 +357,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "24-ace-striker",
+            "_id": "24",
             "jobQueryString": "ace-striker",
             "jobType": "Warrior",
             "jobName": "Ace Striker",
@@ -372,7 +372,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "25-mythic-sage",
+            "_id": "25",
             "jobQueryString": "mythic-sage",
             "jobType": "Mage",
             "jobName": "Mythic Sage",
@@ -387,7 +387,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "26-mythic-ninja",
+            "_id": "26",
             "jobQueryString": "mythic-ninja",
             "jobType": "Ranger",
             "jobName": "Mythic Ninja",
@@ -402,7 +402,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "27-mythic-knight",
+            "_id": "27",
             "jobQueryString": "mythic-knight",
             "jobType": "Warrior",
             "jobName": "Mythic Knight",
@@ -417,7 +417,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "28-paladin",
+            "_id": "28",
             "jobQueryString": "paladin",
             "jobType": "Warrior",
             "jobName": "Paladin",
@@ -431,7 +431,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "29-devout",
+            "_id": "29",
             "jobQueryString": "devout",
             "jobType": "Mage",
             "jobName": "Devout",
@@ -445,7 +445,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "30-viking",
+            "_id": "30",
             "jobQueryString": "viking",
             "jobType": "Ranger",
             "jobName": "Viking",
@@ -459,7 +459,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "31-soldier-1st-class",
+            "_id": "31",
             "jobQueryString": "soldier-1st-class",
             "jobType": "Warrior",
             "jobName": "Soldier 1st Class",
@@ -474,7 +474,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "32-rogue",
+            "_id": "32",
             "jobQueryString": "rogue",
             "jobType": "Ranger",
             "jobName": "Rogue",
@@ -488,7 +488,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "33-berserker",
+            "_id": "33",
             "jobQueryString": "berserker",
             "jobType": "Warrior",
             "jobName": "Berserker",
@@ -502,7 +502,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "34-heretic-knight",
+            "_id": "34",
             "jobQueryString": "heretic-knight",
             "jobType": "Warrior",
             "jobName": "Heretic Knight",
@@ -517,7 +517,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "35-occultist",
+            "_id": "35",
             "jobQueryString": "occultist",
             "jobType": "Mage",
             "jobName": "Occultist",
@@ -531,7 +531,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "36-monk",
+            "_id": "36",
             "jobQueryString": "monk",
             "jobType": "Monk",
             "jobName": "Monk",
@@ -545,7 +545,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
         {
-            "_id": "37-pugilist",
+            "_id": "37",
             "jobQueryString": "pugilist",
             "jobType": "Monk",
             "jobName": "Pugilist",
@@ -559,7 +559,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
         {
-            "_id": "38-grappler",
+            "_id": "38",
             "jobQueryString": "grappler",
             "jobType": "Monk",
             "jobName": "Grappler",
@@ -573,7 +573,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
         {
-            "_id": "39-bard",
+            "_id": "39",
             "jobQueryString": "bard",
             "jobType": "Ranger",
             "jobName": "Bard",
@@ -587,7 +587,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "40-hermit",
+            "_id": "40",
             "jobQueryString": "hermit",
             "jobType": "Monk",
             "jobName": "Hermit",
@@ -601,7 +601,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
         {
-            "_id": "41-tactician",
+            "_id": "41",
             "jobQueryString": "tactician",
             "jobType": "Mage",
             "jobName": "Tactician",
@@ -615,7 +615,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "42-judge-magister",
+            "_id": "42",
             "jobQueryString": "judge-magister",
             "jobType": "Ranger",
             "jobName": "Judge Magister",
@@ -630,7 +630,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "43-high-wind",
+            "_id": "43",
             "jobQueryString": "high-wind",
             "jobType": "Warrior",
             "jobName": "High Wind",
@@ -644,7 +644,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "44-balamb-mercenary",
+            "_id": "44",
             "jobQueryString": "balamb-mercenary",
             "jobType": "Warrior",
             "jobName": "Balamb Mercenary",
@@ -659,7 +659,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "45-tonberry-suit",
+            "_id": "45",
             "jobQueryString": "tonberry-suit",
             "jobType": "Mage",
             "jobName": "Tonberry Suit",
@@ -674,7 +674,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "46-thief-of-tantalus",
+            "_id": "46",
             "jobQueryString": "thief-of-tantalus",
             "jobType": "Ranger",
             "jobName": "Thief of Tantalus",
@@ -689,7 +689,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "47-moogle-suit",
+            "_id": "47",
             "jobQueryString": "moogle-suit",
             "jobType": "Monk",
             "jobName": "Moogle Suit",
@@ -704,7 +704,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
         {
-            "_id": "48-hope's-guide",
+            "_id": "48",
             "jobQueryString": "hope's-guide",
             "jobType": "Mage",
             "jobName": "Hope's Guide",
@@ -719,7 +719,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "49-unbroken-hero",
+            "_id": "49",
             "jobQueryString": "unbroken-hero",
             "jobType": "Monk",
             "jobName": "Unbroken Hero",
@@ -734,7 +734,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
         {
-            "_id": "50-lightning",
+            "_id": "50",
             "jobQueryString": "lightning",
             "jobType": "Ranger",
             "jobName": "Lightning",
@@ -757,7 +757,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "51-knight-of-etro",
+            "_id": "51",
             "jobQueryString": "knight-of-etro",
             "jobType": "Warrior",
             "jobName": "Knight of Etro",
@@ -772,7 +772,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "52-last-hunter",
+            "_id": "52",
             "jobQueryString": "last-hunter",
             "jobType": "Ranger",
             "jobName": "Last Hunter",
@@ -787,7 +787,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "53-fauviste",
+            "_id": "53",
             "jobQueryString": "fauviste",
             "jobType": "Meia",
             "jobName": "Fauviste",
@@ -801,7 +801,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "54-warrior-[hof]",
+            "_id": "54",
             "jobQueryString": "warrior-[hof]",
             "jobType": "Warrior",
             "jobName": "Warrior [HoF]",
@@ -832,7 +832,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "55-mage-[hof]",
+            "_id": "55",
             "jobQueryString": "mage-[hof]",
             "jobType": "Mage",
             "jobName": "Mage [HoF]",
@@ -863,7 +863,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "56-ranger-[hof]",
+            "_id": "56",
             "jobQueryString": "ranger-[hof]",
             "jobType": "Ranger",
             "jobName": "Ranger [HoF]",
@@ -894,7 +894,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "57-knight-[hof]",
+            "_id": "57",
             "jobQueryString": "knight-[hof]",
             "jobType": "Warrior",
             "jobName": "Knight [HoF]",
@@ -929,7 +929,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "58-esmeralda",
+            "_id": "58",
             "jobQueryString": "esmeralda",
             "jobType": "Meia",
             "jobName": "Esmeralda",
@@ -943,7 +943,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "59-hunter-[hof]",
+            "_id": "59",
             "jobQueryString": "hunter-[hof]",
             "jobType": "Ranger",
             "jobName": "Hunter [HoF]",
@@ -976,7 +976,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "60-white-mage-[hof]",
+            "_id": "60",
             "jobQueryString": "white-mage-[hof]",
             "jobType": "Mage",
             "jobName": "White Mage [HoF]",
@@ -1009,7 +1009,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "61-amalthea",
+            "_id": "61",
             "jobQueryString": "amalthea",
             "jobType": "Meia",
             "jobName": "Amalthea",
@@ -1023,7 +1023,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "62-dark-knight-[hof]",
+            "_id": "62",
             "jobQueryString": "dark-knight-[hof]",
             "jobType": "Warrior",
             "jobName": "Dark Knight [HoF]",
@@ -1058,7 +1058,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "63-black-mage-[hof]",
+            "_id": "63",
             "jobQueryString": "black-mage-[hof]",
             "jobType": "Mage",
             "jobName": "Black Mage [HoF]",
@@ -1093,7 +1093,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "64-master-monk",
+            "_id": "64",
             "jobQueryString": "master-monk",
             "jobType": "Monk",
             "jobName": "Master Monk",
@@ -1107,7 +1107,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
         {
-            "_id": "65-thief-[hof]",
+            "_id": "65",
             "jobQueryString": "thief-[hof]",
             "jobType": "Ranger",
             "jobName": "Thief [HoF]",
@@ -1141,7 +1141,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "66-cloud-strife",
+            "_id": "66",
             "jobQueryString": "cloud-strife",
             "jobType": "Warrior",
             "jobName": "Cloud Strife",
@@ -1165,7 +1165,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "67-soldier-1st-class-[hof]",
+            "_id": "67",
             "jobQueryString": "soldier-1st-class-[hof]",
             "jobType": "Warrior",
             "jobName": "Soldier 1st Class [HoF]",
@@ -1204,7 +1204,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "68-ace-striker-[hof]",
+            "_id": "68",
             "jobQueryString": "ace-striker-[hof]",
             "jobType": "Warrior",
             "jobName": "Ace Striker [HoF]",
@@ -1240,7 +1240,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "69-santa-lucia",
+            "_id": "69",
             "jobQueryString": "santa-lucia",
             "jobType": "Meia",
             "jobName": "Santa Lucia",
@@ -1254,7 +1254,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "70-ninja",
+            "_id": "70",
             "jobQueryString": "ninja",
             "jobType": "Ranger",
             "jobName": "Ninja",
@@ -1268,7 +1268,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "71-red-mage-[hof]",
+            "_id": "71",
             "jobQueryString": "red-mage-[hof]",
             "jobType": "Mage",
             "jobName": "Red Mage [HoF]",
@@ -1303,7 +1303,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "72-samurai-[hof]",
+            "_id": "72",
             "jobQueryString": "samurai-[hof]",
             "jobType": "Warrior",
             "jobName": "Samurai [HoF]",
@@ -1338,7 +1338,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "73-glam-vamp",
+            "_id": "73",
             "jobQueryString": "glam-vamp",
             "jobType": "Meia",
             "jobName": "Glam Vamp",
@@ -1352,7 +1352,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "74-assassin-[hof]",
+            "_id": "74",
             "jobQueryString": "assassin-[hof]",
             "jobType": "Ranger",
             "jobName": "Assassin [HoF]",
@@ -1388,7 +1388,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "75-hero-of-despair",
+            "_id": "75",
             "jobQueryString": "hero-of-despair",
             "jobType": "Warrior",
             "jobName": "Hero of Despair",
@@ -1403,7 +1403,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "76-sephiroth",
+            "_id": "76",
             "jobQueryString": "sephiroth",
             "jobType": "Warrior",
             "jobName": "Sephiroth",
@@ -1430,7 +1430,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "77-flower-girl-of-midgar",
+            "_id": "77",
             "jobQueryString": "flower-girl-of-midgar",
             "jobType": "Meia",
             "jobName": "Flower Girl of Midgar",
@@ -1445,7 +1445,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "78-cait-sith",
+            "_id": "78",
             "jobQueryString": "cait-sith",
             "jobType": "Ranger",
             "jobName": "Cait Sith",
@@ -1460,7 +1460,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "79-sage",
+            "_id": "79",
             "jobQueryString": "sage",
             "jobType": "Mage",
             "jobName": "Sage",
@@ -1474,7 +1474,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "80-sword-saint-(atk)",
+            "_id": "80",
             "jobQueryString": "sword-saint-(atk)",
             "jobType": "Warrior",
             "jobName": "Sword Saint (ATK)",
@@ -1488,7 +1488,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "81-sword-saint-(def)",
+            "_id": "81",
             "jobQueryString": "sword-saint-(def)",
             "jobType": "Warrior",
             "jobName": "Sword Saint (DEF)",
@@ -1502,7 +1502,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "82-cocoon-aviator",
+            "_id": "82",
             "jobQueryString": "cocoon-aviator",
             "jobType": "Ranger",
             "jobName": "Cocoon Aviator",
@@ -1541,7 +1541,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "83-dragoon-[hof]",
+            "_id": "83",
             "jobQueryString": "dragoon-[hof]",
             "jobType": "Warrior",
             "jobName": "Dragoon [HoF]",
@@ -1580,7 +1580,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "84-psicom-officer",
+            "_id": "84",
             "jobQueryString": "psicom-officer",
             "jobType": "Meia",
             "jobName": "PSICOM Officer",
@@ -1594,7 +1594,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "85-scholar-[hof]",
+            "_id": "85",
             "jobQueryString": "scholar-[hof]",
             "jobType": "Mage",
             "jobName": "Scholar [HoF]",
@@ -1631,7 +1631,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "86-dancer-[hof]",
+            "_id": "86",
             "jobQueryString": "dancer-[hof]",
             "jobType": "Ranger",
             "jobName": "Dancer [HoF]",
@@ -1669,7 +1669,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "87-vesna-krasna",
+            "_id": "87",
             "jobQueryString": "vesna-krasna",
             "jobType": "Meia",
             "jobName": "Vesna Krasna",
@@ -1683,7 +1683,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "88-eorzea's-paladin",
+            "_id": "88",
             "jobQueryString": "eorzea's-paladin",
             "jobType": "Warrior",
             "jobName": "Eorzea's Paladin",
@@ -1729,7 +1729,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "89-y'shtola",
+            "_id": "89",
             "jobQueryString": "y'shtola",
             "jobType": "Mage",
             "jobName": "Y'shtola",
@@ -1751,7 +1751,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "90-mythic-sage-[hof]",
+            "_id": "90",
             "jobQueryString": "mythic-sage-[hof]",
             "jobType": "Mage",
             "jobName": "Mythic Sage [HoF]",
@@ -1794,7 +1794,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "91-mythic-ninja-[hof]",
+            "_id": "91",
             "jobQueryString": "mythic-ninja-[hof]",
             "jobType": "Ranger",
             "jobName": "Mythic Ninja [HoF]",
@@ -1835,7 +1835,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "92-mythic-knight-[hof]",
+            "_id": "92",
             "jobQueryString": "mythic-knight-[hof]",
             "jobType": "Warrior",
             "jobName": "Mythic Knight [HoF]",
@@ -1876,7 +1876,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "93-paladin-[hof]",
+            "_id": "93",
             "jobQueryString": "paladin-[hof]",
             "jobType": "Warrior",
             "jobName": "Paladin [HoF]",
@@ -1910,7 +1910,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "94-eorzean-bard",
+            "_id": "94",
             "jobQueryString": "eorzean-bard",
             "jobType": "Sarah",
             "jobName": "Eorzean Bard",
@@ -1953,7 +1953,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "95-viking-[hof]",
+            "_id": "95",
             "jobQueryString": "viking-[hof]",
             "jobType": "Ranger",
             "jobName": "Viking [HoF]",
@@ -1998,7 +1998,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "96-devout-[hof]",
+            "_id": "96",
             "jobQueryString": "devout-[hof]",
             "jobType": "Mage",
             "jobName": "Devout [HoF]",
@@ -2031,7 +2031,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "97-crimson-archer",
+            "_id": "97",
             "jobQueryString": "crimson-archer",
             "jobType": "Sarah",
             "jobName": "Crimson Archer",
@@ -2071,7 +2071,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "98-nachtflug",
+            "_id": "98",
             "jobQueryString": "nachtflug",
             "jobType": "Sarah",
             "jobName": "Nachtflug",
@@ -2115,7 +2115,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "99-heretical-knight-[hof]",
+            "_id": "99",
             "jobQueryString": "heretical-knight-[hof]",
             "jobType": "Warrior",
             "jobName": "Heretical Knight [HoF]",
@@ -2152,7 +2152,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "100-primeval-witch",
+            "_id": "100",
             "jobQueryString": "primeval-witch",
             "jobType": "Meia",
             "jobName": "Primeval Witch",
@@ -2211,7 +2211,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "101-judge-magister-[hof]",
+            "_id": "101",
             "jobQueryString": "judge-magister-[hof]",
             "jobType": "Ranger",
             "jobName": "Judge Magister [HoF]",
@@ -2251,7 +2251,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "102-prima-donna",
+            "_id": "102",
             "jobQueryString": "prima-donna",
             "jobType": "Sarah",
             "jobName": "Prima Donna",
@@ -2292,7 +2292,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "103-beach-queen",
+            "_id": "103",
             "jobQueryString": "beach-queen",
             "jobType": "Sarah",
             "jobName": "Beach Queen",
@@ -2334,7 +2334,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "104-deep-diver",
+            "_id": "104",
             "jobQueryString": "deep-diver",
             "jobType": "Monk",
             "jobName": "Deep Diver",
@@ -2379,7 +2379,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
         {
-            "_id": "105-mellow-mermaid",
+            "_id": "105",
             "jobQueryString": "mellow-mermaid",
             "jobType": "Meia",
             "jobName": "Mellow Mermaid",
@@ -2425,7 +2425,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "106-tidus",
+            "_id": "106",
             "jobQueryString": "tidus",
             "jobType": "Ranger",
             "jobName": "Tidus",
@@ -2448,7 +2448,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "107-legendary-guardian",
+            "_id": "107",
             "jobQueryString": "legendary-guardian",
             "jobType": "Warrior",
             "jobName": "Legendary Guardian",
@@ -2496,7 +2496,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "108-ascetic-(atk)",
+            "_id": "108",
             "jobQueryString": "ascetic-(atk)",
             "jobType": "Monk",
             "jobName": "Ascetic (ATK)",
@@ -2542,7 +2542,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
         {
-            "_id": "109-ascetic-(def)",
+            "_id": "109",
             "jobQueryString": "ascetic-(def)",
             "jobType": "Monk",
             "jobName": "Ascetic (DEF)",
@@ -2588,7 +2588,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
         {
-            "_id": "110-proud-cygnus",
+            "_id": "110",
             "jobQueryString": "proud-cygnus",
             "jobType": "Sarah",
             "jobName": "Proud Cygnus",
@@ -2630,7 +2630,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "111-al-bhed-huntress",
+            "_id": "111",
             "jobQueryString": "al-bhed-huntress",
             "jobType": "Sarah",
             "jobName": "Al-Bhed Huntress",
@@ -2673,7 +2673,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "112-vana'diel-geomancer",
+            "_id": "112",
             "jobQueryString": "vana'diel-geomancer",
             "jobType": "Meia",
             "jobName": "Vana'diel Geomancer",
@@ -2724,7 +2724,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "113-vana'diel-monk",
+            "_id": "113",
             "jobQueryString": "vana'diel-monk",
             "jobType": "Monk",
             "jobName": "Vana'diel Monk",
@@ -2770,7 +2770,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
         {
-            "_id": "114-shorn-one",
+            "_id": "114",
             "jobQueryString": "shorn-one",
             "jobType": "Warrior",
             "jobName": "Shorn One",
@@ -2815,7 +2815,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "115-skyseer",
+            "_id": "115",
             "jobQueryString": "skyseer",
             "jobType": "Mage",
             "jobName": "Skyseer",
@@ -2860,7 +2860,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "116-gambler",
+            "_id": "116",
             "jobQueryString": "gambler",
             "jobType": "Ranger",
             "jobName": "Gambler",
@@ -2906,7 +2906,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "117-night-walker",
+            "_id": "117",
             "jobQueryString": "night-walker",
             "jobType": "Meia",
             "jobName": "Night Walker",
@@ -2949,7 +2949,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "118-materia-hunter",
+            "_id": "118",
             "jobQueryString": "materia-hunter",
             "jobType": "Sarah",
             "jobName": "Materia Hunter",
@@ -2994,7 +2994,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "119-agent-of-scarlet-woe",
+            "_id": "119",
             "jobQueryString": "agent-of-scarlet-woe",
             "jobType": "Monk",
             "jobName": "Agent Of Scarlet Woe",
@@ -3039,7 +3039,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
         {
-            "_id": "120-tifa",
+            "_id": "120",
             "jobQueryString": "tifa",
             "jobType": "Ranger",
             "jobName": "Tifa",
@@ -3061,7 +3061,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "121-dawn-warrior",
+            "_id": "121",
             "jobQueryString": "dawn-warrior",
             "jobType": "Warrior",
             "jobName": "Dawn Warrior",
@@ -3082,7 +3082,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "122-wild-rider",
+            "_id": "122",
             "jobQueryString": "wild-rider",
             "jobType": "Sophie",
             "jobName": "Wild Rider",
@@ -3121,7 +3121,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
         {
-            "_id": "123-hermit-[hof]",
+            "_id": "123",
             "jobQueryString": "hermit-[hof]",
             "jobType": "Monk",
             "jobName": "Hermit [HoF]",
@@ -3166,7 +3166,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
         {
-            "_id": "124-jet-stunner",
+            "_id": "124",
             "jobQueryString": "jet-stunner",
             "jobType": "Sophie",
             "jobName": "Jet Stunner",
@@ -3211,7 +3211,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
         {
-            "_id": "125-magitek-jester",
+            "_id": "125",
             "jobQueryString": "magitek-jester",
             "jobType": "Mage",
             "jobName": "Magitek Jester",
@@ -3259,7 +3259,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "126-magitek-heroine",
+            "_id": "126",
             "jobQueryString": "magitek-heroine",
             "jobType": "Sarah",
             "jobName": "Magitek Heroine",
@@ -3304,7 +3304,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "127-balamb-mercenary-[hof]",
+            "_id": "127",
             "jobQueryString": "balamb-mercenary-[hof]",
             "jobType": "Warrior",
             "jobName": "Balamb Mercenary [HoF]",
@@ -3346,7 +3346,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "128-tonberry-suit-[hof]",
+            "_id": "128",
             "jobQueryString": "tonberry-suit-[hof]",
             "jobType": "Mage",
             "jobName": "Tonberry Suit [HoF]",
@@ -3386,7 +3386,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "129-thief-of-tantalus-[hof]",
+            "_id": "129",
             "jobQueryString": "thief-of-tantalus-[hof]",
             "jobType": "Ranger",
             "jobName": "Thief of Tantalus [Hof]",
@@ -3427,7 +3427,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "130-moogle-suit-[hof]",
+            "_id": "130",
             "jobQueryString": "moogle-suit-[hof]",
             "jobType": "Monk",
             "jobName": "Moogle Suit [HoF]",
@@ -3465,7 +3465,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
         {
-            "_id": "131-gardien",
+            "_id": "131",
             "jobQueryString": "gardien",
             "jobType": "Graff",
             "jobName": "Gardien",
@@ -3506,7 +3506,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "132-toredor",
+            "_id": "132",
             "jobQueryString": "toredor",
             "jobType": "Graff",
             "jobName": "Toredor",
@@ -3551,7 +3551,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "133-gilgamesh",
+            "_id": "133",
             "jobQueryString": "gilgamesh",
             "jobType": "Ranger",
             "jobName": "Gilgamesh",
@@ -3573,7 +3573,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "134-cacciatrice",
+            "_id": "134",
             "jobQueryString": "cacciatrice",
             "jobType": "Sarah",
             "jobName": "Cacciatrice",
@@ -3622,7 +3622,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "135-stranger-to-the-mythos",
+            "_id": "135",
             "jobQueryString": "stranger-to-the-mythos",
             "jobType": "Sophie",
             "jobName": "Stranger to the Mythos",
@@ -3669,7 +3669,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
         {
-            "_id": "136-paradox-wanderer",
+            "_id": "136",
             "jobQueryString": "paradox-wanderer",
             "jobType": "Sarah",
             "jobName": "Paradox Wanderer",
@@ -3718,7 +3718,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "137-scharfrichter-(atk)",
+            "_id": "137",
             "jobQueryString": "scharfrichter-(atk)",
             "jobType": "Warrior",
             "jobName": "Scharfrichter (ATK)",
@@ -3776,7 +3776,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "138-scharfrichter-(def)",
+            "_id": "138",
             "jobQueryString": "scharfrichter-(def)",
             "jobType": "Warrior",
             "jobName": "Scharfrichter (DEF)",
@@ -3834,7 +3834,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "139-esmeralda-[hof]",
+            "_id": "139",
             "jobQueryString": "esmeralda-[hof]",
             "jobType": "Meia",
             "jobName": "Esmeralda [HoF]",
@@ -3876,7 +3876,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "140-fauviste-[hof]",
+            "_id": "140",
             "jobQueryString": "fauviste-[hof]",
             "jobType": "Meia",
             "jobName": "Fauviste [HoF]",
@@ -3917,7 +3917,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "141-amalthea-[hof]",
+            "_id": "141",
             "jobQueryString": "amalthea-[hof]",
             "jobType": "Meia",
             "jobName": "Amalthea [HoF]",
@@ -3962,7 +3962,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "142-kampfer-(atk)",
+            "_id": "142",
             "jobQueryString": "kampfer-(atk)",
             "jobType": "Monk",
             "jobName": "Kampfer (ATK)",
@@ -4021,7 +4021,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
         {
-            "_id": "143-kampfer-(def)",
+            "_id": "143",
             "jobQueryString": "kampfer-(def)",
             "jobType": "Monk",
             "jobName": "Kampfer (DEF)",
@@ -4079,7 +4079,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
         {
-            "_id": "144-tropical-traveler",
+            "_id": "144",
             "jobQueryString": "tropical-traveler",
             "jobType": "Sophie",
             "jobName": "Tropical Traveler",
@@ -4087,42 +4087,42 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
         {
-            "_id": "145-sword-saint-(atk)-[hof]",
+            "_id": "145",
             "jobQueryString": "sword-saint-(atk)-[hof]",
             "jobType": "Warrior",
             "jobName": "Sword Saint (ATK) [HoF]",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "146-sword-saint-(def)-[hof]",
+            "_id": "146",
             "jobQueryString": "sword-saint-(def)-[hof]",
             "jobType": "Warrior",
             "jobName": "Sword Saint (DEF) [HoF]",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "147-sage-[hof]",
+            "_id": "147",
             "jobQueryString": "sage-[hof]",
             "jobType": "Mage",
             "jobName": "Sage [HoF]",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "148-vagabond",
+            "_id": "148",
             "jobQueryString": "vagabond",
             "jobType": "Graff",
             "jobName": "Vagabond",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "149-ninja-[hof]",
+            "_id": "149",
             "jobQueryString": "ninja-[hof]",
             "jobType": "Ranger",
             "jobName": "Ninja [HoF]",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "150-sorceress's-knight",
+            "_id": "150",
             "jobQueryString": "sorceress's-knight",
             "jobType": "Graff",
             "jobName": "Sorceress's Knight",
@@ -4130,7 +4130,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "151-squall-leonhart",
+            "_id": "151",
             "jobQueryString": "squall-leonhart",
             "jobType": "Warrior",
             "jobName": "Squall Leonhart",
@@ -4138,7 +4138,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "152-squall",
+            "_id": "152",
             "jobQueryString": "squall",
             "jobType": "Warrior",
             "jobName": "Squall",
@@ -4146,7 +4146,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
         {
-            "_id": "153-sorceress-of-oblivion",
+            "_id": "153",
             "jobQueryString": "sorceress-of-oblivion",
             "jobType": "Meia",
             "jobName": "Sorceress of Oblivion",
@@ -4154,7 +4154,7 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "154-reisender",
+            "_id": "154",
             "jobQueryString": "reisender",
             "jobType": "Ranger",
             "jobName": "Reisender",
@@ -4162,21 +4162,21 @@
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
         {
-            "_id": "155-glam-vamp-[hof]",
+            "_id": "155",
             "jobQueryString": "glam-vamp-[hof]",
             "jobType": "Meia",
             "jobName": "Glam Vamp [HoF]",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "156-vesna-krasna-[hof]",
+            "_id": "156",
             "jobQueryString": "vesna-krasna-[hof]",
             "jobType": "Meia",
             "jobName": "Vesna Krasna [HoF]",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
         {
-            "_id": "157-wahrsager",
+            "_id": "157",
             "jobQueryString": "wahrsager",
             "jobType": "Mage",
             "jobName": "Wahrsager",

--- a/src/jobs.json
+++ b/src/jobs.json
@@ -1,7 +1,7 @@
 [
-    {
-        "onion-knight": {
-            "jobId": "1-onion-knight",
+    [
+        {
+            "_id": "1-onion-knight",
             "jobQueryString": "onion-knight",
             "jobType": "Warrior",
             "jobName": "Onion Knight",
@@ -17,8 +17,8 @@
             "jobMpRole": "ATK",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "apprentice-mage": {
-            "jobId": "2-apprentice-mage",
+        {
+            "_id": "2-apprentice-mage",
             "jobQueryString": "apprentice-mage",
             "jobType": "Mage",
             "jobName": "Apprentice Mage",
@@ -33,8 +33,8 @@
             "jobOrbSet2": "Fire-Water-Light",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "neophyte-ranger": {
-            "jobId": "3-neophyte-ranger",
+        {
+            "_id": "3-neophyte-ranger",
             "jobQueryString": "neophyte-ranger",
             "jobType": "Ranger",
             "jobName": "Neophyte Ranger",
@@ -49,8 +49,8 @@
             "jobOrbSet2": "Water-Wind-Dark",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "trainee-monk": {
-            "jobId": "4-trainee-monk",
+        {
+            "_id": "4-trainee-monk",
             "jobQueryString": "trainee-monk",
             "jobType": "Monk",
             "jobName": "Trainee Monk",
@@ -64,8 +64,8 @@
             "jobOrbSet1": "Fire-Water-Earth",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
-        "the-azure-witch": {
-            "jobId": "5-the-azure-witch",
+        {
+            "_id": "5-the-azure-witch",
             "jobQueryString": "the-azure-witch",
             "jobType": "Meia",
             "jobName": "The Azure Witch",
@@ -81,8 +81,8 @@
             "jobOrbSet3": "Water-Light-Dark",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "battle-princess": {
-            "jobId": "6-battle-princess",
+        {
+            "_id": "6-battle-princess",
             "jobQueryString": "battle-princess",
             "jobType": "Sarah",
             "jobName": "Battle Princess",
@@ -97,8 +97,8 @@
             "jobOrbSet2": "Fire-Water-Light",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "freelancer": {
-            "jobId": "7-freelancer",
+        {
+            "_id": "7-freelancer",
             "jobQueryString": "freelancer",
             "jobType": "Sophie",
             "jobName": "Freelancer",
@@ -114,8 +114,8 @@
             "jobOrbSet3": "Fire-Wind-Dark",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
-        "epeiste": {
-            "jobId": "8-epeiste",
+        {
+            "_id": "8-epeiste",
             "jobQueryString": "epeiste",
             "jobType": "Graff",
             "jobName": "Epeiste",
@@ -131,8 +131,8 @@
             "jobOrbSet3": "Fire-Water-Dark",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "warrior": {
-            "jobId": "9-warrior",
+        {
+            "_id": "9-warrior",
             "jobQueryString": "warrior",
             "jobType": "Warrior",
             "jobName": "Warrior",
@@ -146,8 +146,8 @@
             "jobOrbSet1": "Fire-Water-Earth",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "knight": {
-            "jobId": "10-knight",
+        {
+            "_id": "10-knight",
             "jobQueryString": "knight",
             "jobType": "Warrior",
             "jobName": "Knight",
@@ -161,8 +161,8 @@
             "jobOrbSet1": "Fire-Wind-Earth",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "mage": {
-            "jobId": "11-mage",
+        {
+            "_id": "11-mage",
             "jobQueryString": "mage",
             "jobType": "Mage",
             "jobName": "Mage",
@@ -176,8 +176,8 @@
             "jobOrbSet1": "Fire-Water-Wind",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "white-mage": {
-            "jobId": "12-white-mage",
+        {
+            "_id": "12-white-mage",
             "jobQueryString": "white-mage",
             "jobType": "Mage",
             "jobName": "White Mage",
@@ -191,8 +191,8 @@
             "jobOrbSet1": "Fire-Water-Earth",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "ranger": {
-            "jobId": "13-ranger",
+        {
+            "_id": "13-ranger",
             "jobQueryString": "ranger",
             "jobType": "Ranger",
             "jobName": "Ranger",
@@ -206,8 +206,8 @@
             "jobOrbSet1": "Water-Wind-Earth",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "hunter": {
-            "jobId": "14-hunter",
+        {
+            "_id": "14-hunter",
             "jobQueryString": "hunter",
             "jobType": "Ranger",
             "jobName": "Hunter",
@@ -221,8 +221,8 @@
             "jobOrbSet1": "Fire-Water-Wind",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "dark-knight": {
-            "jobId": "15-dark-knight",
+        {
+            "_id": "15-dark-knight",
             "jobQueryString": "dark-knight",
             "jobType": "Warrior",
             "jobName": "Dark Knight",
@@ -236,8 +236,8 @@
             "jobOrbSet1": "Fire-Water-Wind",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "black-mage": {
-            "jobId": "16-black-mage",
+        {
+            "_id": "16-black-mage",
             "jobQueryString": "black-mage",
             "jobType": "Mage",
             "jobName": "Black Mage",
@@ -251,8 +251,8 @@
             "jobOrbSet1": "Water-Wind-Earth",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "thief": {
-            "jobId": "17-thief",
+        {
+            "_id": "17-thief",
             "jobQueryString": "thief",
             "jobType": "Ranger",
             "jobName": "Thief",
@@ -266,8 +266,8 @@
             "jobOrbSet1": "Fire-Wind-Earth",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "samurai": {
-            "jobId": "18-samurai",
+        {
+            "_id": "18-samurai",
             "jobQueryString": "samurai",
             "jobType": "Warrior",
             "jobName": "Samurai",
@@ -281,8 +281,8 @@
             "jobOrbSet1": "Water-Wind-Earth",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "red-mage": {
-            "jobId": "19-red-mage",
+        {
+            "_id": "19-red-mage",
             "jobQueryString": "red-mage",
             "jobType": "Mage",
             "jobName": "Red Mage",
@@ -296,8 +296,8 @@
             "jobOrbSet1": "Fire-Wind-Earth",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "assassin": {
-            "jobId": "20-assassin",
+        {
+            "_id": "20-assassin",
             "jobQueryString": "assassin",
             "jobType": "Ranger",
             "jobName": "Assassin",
@@ -311,8 +311,8 @@
             "jobOrbSet1": "Fire-Water-Earth",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "dragoon": {
-            "jobId": "21-dragoon",
+        {
+            "_id": "21-dragoon",
             "jobQueryString": "dragoon",
             "jobType": "Warrior",
             "jobName": "Dragoon",
@@ -326,8 +326,8 @@
             "jobOrbSet1": "Fire-Water-Earth",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "scholar": {
-            "jobId": "22-scholar",
+        {
+            "_id": "22-scholar",
             "jobQueryString": "scholar",
             "jobType": "Mage",
             "jobName": "Scholar",
@@ -341,8 +341,8 @@
             "jobOrbSet1": "Fire-Water-Wind",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "dancer": {
-            "jobId": "23-dancer",
+        {
+            "_id": "23-dancer",
             "jobQueryString": "dancer",
             "jobType": "Ranger",
             "jobName": "Dancer",
@@ -356,8 +356,8 @@
             "jobOrbSet1": "Water-Wind-Earth",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "ace-striker": {
-            "jobId": "24-ace-striker",
+        {
+            "_id": "24-ace-striker",
             "jobQueryString": "ace-striker",
             "jobType": "Warrior",
             "jobName": "Ace Striker",
@@ -371,8 +371,8 @@
             "jobStatDefense": 2,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "mythic-sage": {
-            "jobId": "25-mythic-sage",
+        {
+            "_id": "25-mythic-sage",
             "jobQueryString": "mythic-sage",
             "jobType": "Mage",
             "jobName": "Mythic Sage",
@@ -386,8 +386,8 @@
             "jobStatDefense": 2,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "mythic-ninja": {
-            "jobId": "26-mythic-ninja",
+        {
+            "_id": "26-mythic-ninja",
             "jobQueryString": "mythic-ninja",
             "jobType": "Ranger",
             "jobName": "Mythic Ninja",
@@ -401,8 +401,8 @@
             "jobStatDefense": 1,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "mythic-knight": {
-            "jobId": "27-mythic-knight",
+        {
+            "_id": "27-mythic-knight",
             "jobQueryString": "mythic-knight",
             "jobType": "Warrior",
             "jobName": "Mythic Knight",
@@ -416,8 +416,8 @@
             "jobStatDefense": 3,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "paladin": {
-            "jobId": "28-paladin",
+        {
+            "_id": "28-paladin",
             "jobQueryString": "paladin",
             "jobType": "Warrior",
             "jobName": "Paladin",
@@ -430,8 +430,8 @@
             "jobStatDefense": 6,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "devout": {
-            "jobId": "29-devout",
+        {
+            "_id": "29-devout",
             "jobQueryString": "devout",
             "jobType": "Mage",
             "jobName": "Devout",
@@ -444,8 +444,8 @@
             "jobStatDefense": 4,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "viking": {
-            "jobId": "30-viking",
+        {
+            "_id": "30-viking",
             "jobQueryString": "viking",
             "jobType": "Ranger",
             "jobName": "Viking",
@@ -458,8 +458,8 @@
             "jobStatDefense": 1,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "soldier-1st-class": {
-            "jobId": "31-soldier-1st-class",
+        {
+            "_id": "31-soldier-1st-class",
             "jobQueryString": "soldier-1st-class",
             "jobType": "Warrior",
             "jobName": "Soldier 1st Class",
@@ -473,8 +473,8 @@
             "jobStatDefense": 1,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "rogue": {
-            "jobId": "32-rogue",
+        {
+            "_id": "32-rogue",
             "jobQueryString": "rogue",
             "jobType": "Ranger",
             "jobName": "Rogue",
@@ -487,8 +487,8 @@
             "jobStatDefense": 0,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "berserker": {
-            "jobId": "33-berserker",
+        {
+            "_id": "33-berserker",
             "jobQueryString": "berserker",
             "jobType": "Warrior",
             "jobName": "Berserker",
@@ -501,8 +501,8 @@
             "jobStatDefense": 0,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "heretic-knight": {
-            "jobId": "34-heretic-knight",
+        {
+            "_id": "34-heretic-knight",
             "jobQueryString": "heretic-knight",
             "jobType": "Warrior",
             "jobName": "Heretic Knight",
@@ -516,8 +516,8 @@
             "jobStatDefense": 6,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "occultist": {
-            "jobId": "35-occultist",
+        {
+            "_id": "35-occultist",
             "jobQueryString": "occultist",
             "jobType": "Mage",
             "jobName": "Occultist",
@@ -530,8 +530,8 @@
             "jobStatDefense": 0,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "monk": {
-            "jobId": "36-monk",
+        {
+            "_id": "36-monk",
             "jobQueryString": "monk",
             "jobType": "Monk",
             "jobName": "Monk",
@@ -544,8 +544,8 @@
             "jobStatDefense": 2,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
-        "pugilist": {
-            "jobId": "37-pugilist",
+        {
+            "_id": "37-pugilist",
             "jobQueryString": "pugilist",
             "jobType": "Monk",
             "jobName": "Pugilist",
@@ -558,8 +558,8 @@
             "jobStatDefense": 1,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
-        "grappler": {
-            "jobId": "38-grappler",
+        {
+            "_id": "38-grappler",
             "jobQueryString": "grappler",
             "jobType": "Monk",
             "jobName": "Grappler",
@@ -572,8 +572,8 @@
             "jobStatDefense": 4,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
-        "bard": {
-            "jobId": "39-bard",
+        {
+            "_id": "39-bard",
             "jobQueryString": "bard",
             "jobType": "Ranger",
             "jobName": "Bard",
@@ -586,8 +586,8 @@
             "jobStatDefense": 1,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "hermit": {
-            "jobId": "40-hermit",
+        {
+            "_id": "40-hermit",
             "jobQueryString": "hermit",
             "jobType": "Monk",
             "jobName": "Hermit",
@@ -600,8 +600,8 @@
             "jobStatDefense": 2,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
-        "tactician": {
-            "jobId": "41-tactician",
+        {
+            "_id": "41-tactician",
             "jobQueryString": "tactician",
             "jobType": "Mage",
             "jobName": "Tactician",
@@ -614,8 +614,8 @@
             "jobStatDefense": 4,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "judge-magister": {
-            "jobId": "42-judge-magister",
+        {
+            "_id": "42-judge-magister",
             "jobQueryString": "judge-magister",
             "jobType": "Ranger",
             "jobName": "Judge Magister",
@@ -629,8 +629,8 @@
             "jobStatDefense": 2,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "high-wind": {
-            "jobId": "43-high-wind",
+        {
+            "_id": "43-high-wind",
             "jobQueryString": "high-wind",
             "jobType": "Warrior",
             "jobName": "High Wind",
@@ -643,8 +643,8 @@
             "jobStatDefense": 1,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "balamb-mercenary": {
-            "jobId": "44-balamb-mercenary",
+        {
+            "_id": "44-balamb-mercenary",
             "jobQueryString": "balamb-mercenary",
             "jobType": "Warrior",
             "jobName": "Balamb Mercenary",
@@ -658,8 +658,8 @@
             "jobStatDefense": 3,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "tonberry-suit": {
-            "jobId": "45-tonberry-suit",
+        {
+            "_id": "45-tonberry-suit",
             "jobQueryString": "tonberry-suit",
             "jobType": "Mage",
             "jobName": "Tonberry Suit",
@@ -673,8 +673,8 @@
             "jobStatDefense": 3,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "thief-of-tantalus": {
-            "jobId": "46-thief-of-tantalus",
+        {
+            "_id": "46-thief-of-tantalus",
             "jobQueryString": "thief-of-tantalus",
             "jobType": "Ranger",
             "jobName": "Thief of Tantalus",
@@ -688,8 +688,8 @@
             "jobStatDefense": 2,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "moogle-suit": {
-            "jobId": "47-moogle-suit",
+        {
+            "_id": "47-moogle-suit",
             "jobQueryString": "moogle-suit",
             "jobType": "Monk",
             "jobName": "Moogle Suit",
@@ -703,8 +703,8 @@
             "jobStatDefense": 7,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
-        "hope's-guide": {
-            "jobId": "48-hope's-guide",
+        {
+            "_id": "48-hope's-guide",
             "jobQueryString": "hope's-guide",
             "jobType": "Mage",
             "jobName": "Hope's Guide",
@@ -718,8 +718,8 @@
             "jobStatDefense": 2,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "unbroken-hero": {
-            "jobId": "49-unbroken-hero",
+        {
+            "_id": "49-unbroken-hero",
             "jobQueryString": "unbroken-hero",
             "jobType": "Monk",
             "jobName": "Unbroken Hero",
@@ -733,8 +733,8 @@
             "jobStatDefense": 7,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
-        "lightning": {
-            "jobId": "50-lightning",
+        {
+            "_id": "50-lightning",
             "jobQueryString": "lightning",
             "jobType": "Ranger",
             "jobName": "Lightning",
@@ -756,8 +756,8 @@
             "jobUltimateEffectTranceIi": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "knight-of-etro": {
-            "jobId": "51-knight-of-etro",
+        {
+            "_id": "51-knight-of-etro",
             "jobQueryString": "knight-of-etro",
             "jobType": "Warrior",
             "jobName": "Knight of Etro",
@@ -771,8 +771,8 @@
             "jobStatDefense": 4,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "last-hunter": {
-            "jobId": "52-last-hunter",
+        {
+            "_id": "52-last-hunter",
             "jobQueryString": "last-hunter",
             "jobType": "Ranger",
             "jobName": "Last Hunter",
@@ -786,8 +786,8 @@
             "jobStatDefense": 2,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "fauviste": {
-            "jobId": "53-fauviste",
+        {
+            "_id": "53-fauviste",
             "jobQueryString": "fauviste",
             "jobType": "Meia",
             "jobName": "Fauviste",
@@ -800,8 +800,8 @@
             "jobStatDefense": 1,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "warrior-[hof]": {
-            "jobId": "54-warrior-[hof]",
+        {
+            "_id": "54-warrior-[hof]",
             "jobQueryString": "warrior-[hof]",
             "jobType": "Warrior",
             "jobName": "Warrior [HoF]",
@@ -831,8 +831,8 @@
             "jobUltimateEffectDebrave": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "mage-[hof]": {
-            "jobId": "55-mage-[hof]",
+        {
+            "_id": "55-mage-[hof]",
             "jobQueryString": "mage-[hof]",
             "jobType": "Mage",
             "jobName": "Mage [HoF]",
@@ -862,8 +862,8 @@
             "jobUltimateEffectSnipe": "4h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "ranger-[hof]": {
-            "jobId": "56-ranger-[hof]",
+        {
+            "_id": "56-ranger-[hof]",
             "jobQueryString": "ranger-[hof]",
             "jobType": "Ranger",
             "jobName": "Ranger [HoF]",
@@ -893,8 +893,8 @@
             "jobUltimateEffectBoost": "4h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "knight-[hof]": {
-            "jobId": "57-knight-[hof]",
+        {
+            "_id": "57-knight-[hof]",
             "jobQueryString": "knight-[hof]",
             "jobType": "Warrior",
             "jobName": "Knight [HoF]",
@@ -928,8 +928,8 @@
             "jobUltimateEffectWall": "4h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "esmeralda": {
-            "jobId": "58-esmeralda",
+        {
+            "_id": "58-esmeralda",
             "jobQueryString": "esmeralda",
             "jobType": "Meia",
             "jobName": "Esmeralda",
@@ -942,8 +942,8 @@
             "jobStatDefense": 1,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "hunter-[hof]": {
-            "jobId": "59-hunter-[hof]",
+        {
+            "_id": "59-hunter-[hof]",
             "jobQueryString": "hunter-[hof]",
             "jobType": "Ranger",
             "jobName": "Hunter [HoF]",
@@ -975,8 +975,8 @@
             "jobUltimateEffectSnipe": "4h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "white-mage-[hof]": {
-            "jobId": "60-white-mage-[hof]",
+        {
+            "_id": "60-white-mage-[hof]",
             "jobQueryString": "white-mage-[hof]",
             "jobType": "Mage",
             "jobName": "White Mage [HoF]",
@@ -1008,8 +1008,8 @@
             "jobUltimateEffectRegen": "4h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "amalthea": {
-            "jobId": "61-amalthea",
+        {
+            "_id": "61-amalthea",
             "jobQueryString": "amalthea",
             "jobType": "Meia",
             "jobName": "Amalthea",
@@ -1022,8 +1022,8 @@
             "jobStatDefense": 1,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "dark-knight-[hof]": {
-            "jobId": "62-dark-knight-[hof]",
+        {
+            "_id": "62-dark-knight-[hof]",
             "jobQueryString": "dark-knight-[hof]",
             "jobType": "Warrior",
             "jobName": "Dark Knight [HoF]",
@@ -1057,8 +1057,8 @@
             "jobUltimateEffectSnipe": "4h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "black-mage-[hof]": {
-            "jobId": "63-black-mage-[hof]",
+        {
+            "_id": "63-black-mage-[hof]",
             "jobQueryString": "black-mage-[hof]",
             "jobType": "Mage",
             "jobName": "Black Mage [HoF]",
@@ -1092,8 +1092,8 @@
             "jobUltimateEffectCurse": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "master-monk": {
-            "jobId": "64-master-monk",
+        {
+            "_id": "64-master-monk",
             "jobQueryString": "master-monk",
             "jobType": "Monk",
             "jobName": "Master Monk",
@@ -1106,8 +1106,8 @@
             "jobStatDefense": 3,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
-        "thief-[hof]": {
-            "jobId": "65-thief-[hof]",
+        {
+            "_id": "65-thief-[hof]",
             "jobQueryString": "thief-[hof]",
             "jobType": "Ranger",
             "jobName": "Thief [HoF]",
@@ -1140,8 +1140,8 @@
             "jobUltimateEffectStun": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "cloud-strife": {
-            "jobId": "66-cloud-strife",
+        {
+            "_id": "66-cloud-strife",
             "jobQueryString": "cloud-strife",
             "jobType": "Warrior",
             "jobName": "Cloud Strife",
@@ -1164,8 +1164,8 @@
             "jobUltimateEffectTranceIi": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "soldier-1st-class-[hof]": {
-            "jobId": "67-soldier-1st-class-[hof]",
+        {
+            "_id": "67-soldier-1st-class-[hof]",
             "jobQueryString": "soldier-1st-class-[hof]",
             "jobType": "Warrior",
             "jobName": "Soldier 1st Class [HoF]",
@@ -1203,8 +1203,8 @@
             "jobUltimateEffectTrance": "4h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "ace-striker-[hof]": {
-            "jobId": "68-ace-striker-[hof]",
+        {
+            "_id": "68-ace-striker-[hof]",
             "jobQueryString": "ace-striker-[hof]",
             "jobType": "Warrior",
             "jobName": "Ace Striker [HoF]",
@@ -1239,8 +1239,8 @@
             "jobUltimateEffectSnipe": "4h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "santa-lucia": {
-            "jobId": "69-santa-lucia",
+        {
+            "_id": "69-santa-lucia",
             "jobQueryString": "santa-lucia",
             "jobType": "Meia",
             "jobName": "Santa Lucia",
@@ -1253,8 +1253,8 @@
             "jobStatDefense": 3,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "ninja": {
-            "jobId": "70-ninja",
+        {
+            "_id": "70-ninja",
             "jobQueryString": "ninja",
             "jobType": "Ranger",
             "jobName": "Ninja",
@@ -1267,8 +1267,8 @@
             "jobStatDefense": 1,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "red-mage-[hof]": {
-            "jobId": "71-red-mage-[hof]",
+        {
+            "_id": "71-red-mage-[hof]",
             "jobQueryString": "red-mage-[hof]",
             "jobType": "Mage",
             "jobName": "Red Mage [HoF]",
@@ -1302,8 +1302,8 @@
             "jobUltimateEffectTrance": "4h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "samurai-[hof]": {
-            "jobId": "72-samurai-[hof]",
+        {
+            "_id": "72-samurai-[hof]",
             "jobQueryString": "samurai-[hof]",
             "jobType": "Warrior",
             "jobName": "Samurai [HoF]",
@@ -1337,8 +1337,8 @@
             "jobUltimateEffectTrance": "4h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "glam-vamp": {
-            "jobId": "73-glam-vamp",
+        {
+            "_id": "73-glam-vamp",
             "jobQueryString": "glam-vamp",
             "jobType": "Meia",
             "jobName": "Glam Vamp",
@@ -1351,8 +1351,8 @@
             "jobStatDefense": 2,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "assassin-[hof]": {
-            "jobId": "74-assassin-[hof]",
+        {
+            "_id": "74-assassin-[hof]",
             "jobQueryString": "assassin-[hof]",
             "jobType": "Ranger",
             "jobName": "Assassin [HoF]",
@@ -1387,8 +1387,8 @@
             "jobUltimateEffectTrance": "4h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "hero-of-despair": {
-            "jobId": "75-hero-of-despair",
+        {
+            "_id": "75-hero-of-despair",
             "jobQueryString": "hero-of-despair",
             "jobType": "Warrior",
             "jobName": "Hero of Despair",
@@ -1402,8 +1402,8 @@
             "jobStatDefense": 1,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "sephiroth": {
-            "jobId": "76-sephiroth",
+        {
+            "_id": "76-sephiroth",
             "jobQueryString": "sephiroth",
             "jobType": "Warrior",
             "jobName": "Sephiroth",
@@ -1429,8 +1429,8 @@
             "jobUltimateEffectWeaken": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "flower-girl-of-midgar": {
-            "jobId": "77-flower-girl-of-midgar",
+        {
+            "_id": "77-flower-girl-of-midgar",
             "jobQueryString": "flower-girl-of-midgar",
             "jobType": "Meia",
             "jobName": "Flower Girl of Midgar",
@@ -1444,8 +1444,8 @@
             "jobStatDefense": 1,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "cait-sith": {
-            "jobId": "78-cait-sith",
+        {
+            "_id": "78-cait-sith",
             "jobQueryString": "cait-sith",
             "jobType": "Ranger",
             "jobName": "Cait Sith",
@@ -1459,8 +1459,8 @@
             "jobStatDefense": 0,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "sage": {
-            "jobId": "79-sage",
+        {
+            "_id": "79-sage",
             "jobQueryString": "sage",
             "jobType": "Mage",
             "jobName": "Sage",
@@ -1473,8 +1473,8 @@
             "jobStatDefense": 3,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "sword-saint-(atk)": {
-            "jobId": "80-sword-saint-(atk)",
+        {
+            "_id": "80-sword-saint-(atk)",
             "jobQueryString": "sword-saint-(atk)",
             "jobType": "Warrior",
             "jobName": "Sword Saint (ATK)",
@@ -1487,8 +1487,8 @@
             "jobStatDefense": 3,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "sword-saint-(def)": {
-            "jobId": "81-sword-saint-(def)",
+        {
+            "_id": "81-sword-saint-(def)",
             "jobQueryString": "sword-saint-(def)",
             "jobType": "Warrior",
             "jobName": "Sword Saint (DEF)",
@@ -1501,8 +1501,8 @@
             "jobStatDefense": 9,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "cocoon-aviator": {
-            "jobId": "82-cocoon-aviator",
+        {
+            "_id": "82-cocoon-aviator",
             "jobQueryString": "cocoon-aviator",
             "jobType": "Ranger",
             "jobName": "Cocoon Aviator",
@@ -1540,8 +1540,8 @@
             "jobUltimateEffectSnipe": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "dragoon-[hof]": {
-            "jobId": "83-dragoon-[hof]",
+        {
+            "_id": "83-dragoon-[hof]",
             "jobQueryString": "dragoon-[hof]",
             "jobType": "Warrior",
             "jobName": "Dragoon [HoF]",
@@ -1579,8 +1579,8 @@
             "jobUltimateEffectUnguard": "4h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "psicom-officer": {
-            "jobId": "84-psicom-officer",
+        {
+            "_id": "84-psicom-officer",
             "jobQueryString": "psicom-officer",
             "jobType": "Meia",
             "jobName": "PSICOM Officer",
@@ -1593,8 +1593,8 @@
             "jobStatDefense": 0,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "scholar-[hof]": {
-            "jobId": "85-scholar-[hof]",
+        {
+            "_id": "85-scholar-[hof]",
             "jobQueryString": "scholar-[hof]",
             "jobType": "Mage",
             "jobName": "Scholar [HoF]",
@@ -1630,8 +1630,8 @@
             "jobUltimateEffectWeaken": "x",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "dancer-[hof]": {
-            "jobId": "86-dancer-[hof]",
+        {
+            "_id": "86-dancer-[hof]",
             "jobQueryString": "dancer-[hof]",
             "jobType": "Ranger",
             "jobName": "Dancer [HoF]",
@@ -1668,8 +1668,8 @@
             "jobUltimateEffectSnipe": "4h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "vesna-krasna": {
-            "jobId": "87-vesna-krasna",
+        {
+            "_id": "87-vesna-krasna",
             "jobQueryString": "vesna-krasna",
             "jobType": "Meia",
             "jobName": "Vesna Krasna",
@@ -1682,8 +1682,8 @@
             "jobStatDefense": 0,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "eorzea's-paladin": {
-            "jobId": "88-eorzea's-paladin",
+        {
+            "_id": "88-eorzea's-paladin",
             "jobQueryString": "eorzea's-paladin",
             "jobType": "Warrior",
             "jobName": "Eorzea's Paladin",
@@ -1728,8 +1728,8 @@
             "jobUltimateEffectWall": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "y'shtola": {
-            "jobId": "89-y'shtola",
+        {
+            "_id": "89-y'shtola",
             "jobQueryString": "y'shtola",
             "jobType": "Mage",
             "jobName": "Y'shtola",
@@ -1750,8 +1750,8 @@
             "jobUltimateEffectTranceIi": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "mythic-sage-[hof]": {
-            "jobId": "90-mythic-sage-[hof]",
+        {
+            "_id": "90-mythic-sage-[hof]",
             "jobQueryString": "mythic-sage-[hof]",
             "jobType": "Mage",
             "jobName": "Mythic Sage [HoF]",
@@ -1793,8 +1793,8 @@
             "jobUltimateEffectPrismaticShift": "x",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "mythic-ninja-[hof]": {
-            "jobId": "91-mythic-ninja-[hof]",
+        {
+            "_id": "91-mythic-ninja-[hof]",
             "jobQueryString": "mythic-ninja-[hof]",
             "jobType": "Ranger",
             "jobName": "Mythic Ninja [HoF]",
@@ -1834,8 +1834,8 @@
             "jobUltimateEffectPrismaticShift": "x",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "mythic-knight-[hof]": {
-            "jobId": "92-mythic-knight-[hof]",
+        {
+            "_id": "92-mythic-knight-[hof]",
             "jobQueryString": "mythic-knight-[hof]",
             "jobType": "Warrior",
             "jobName": "Mythic Knight [HoF]",
@@ -1875,8 +1875,8 @@
             "jobUltimateEffectPrismaticShift": "x",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "paladin-[hof]": {
-            "jobId": "93-paladin-[hof]",
+        {
+            "_id": "93-paladin-[hof]",
             "jobQueryString": "paladin-[hof]",
             "jobType": "Warrior",
             "jobName": "Paladin [HoF]",
@@ -1909,8 +1909,8 @@
             "jobUltimateEffectTrance": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "eorzean-bard": {
-            "jobId": "94-eorzean-bard",
+        {
+            "_id": "94-eorzean-bard",
             "jobQueryString": "eorzean-bard",
             "jobType": "Sarah",
             "jobName": "Eorzean Bard",
@@ -1952,8 +1952,8 @@
             "jobUltimateEffectTrance": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "viking-[hof]": {
-            "jobId": "95-viking-[hof]",
+        {
+            "_id": "95-viking-[hof]",
             "jobQueryString": "viking-[hof]",
             "jobType": "Ranger",
             "jobName": "Viking [HoF]",
@@ -1997,8 +1997,8 @@
             "jobUltimateEffectWall": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "devout-[hof]": {
-            "jobId": "96-devout-[hof]",
+        {
+            "_id": "96-devout-[hof]",
             "jobQueryString": "devout-[hof]",
             "jobType": "Mage",
             "jobName": "Devout [HoF]",
@@ -2030,8 +2030,8 @@
             "jobUltimateEffectWall": "4h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "crimson-archer": {
-            "jobId": "97-crimson-archer",
+        {
+            "_id": "97-crimson-archer",
             "jobQueryString": "crimson-archer",
             "jobType": "Sarah",
             "jobName": "Crimson Archer",
@@ -2070,8 +2070,8 @@
             "jobUltimateEffectUnguard": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "nachtflug": {
-            "jobId": "98-nachtflug",
+        {
+            "_id": "98-nachtflug",
             "jobQueryString": "nachtflug",
             "jobType": "Sarah",
             "jobName": "Nachtflug",
@@ -2114,8 +2114,8 @@
             "jobUltimateEffectPrismaticShift": "x",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "heretical-knight-[hof]": {
-            "jobId": "99-heretical-knight-[hof]",
+        {
+            "_id": "99-heretical-knight-[hof]",
             "jobQueryString": "heretical-knight-[hof]",
             "jobType": "Warrior",
             "jobName": "Heretical Knight [HoF]",
@@ -2151,8 +2151,8 @@
             "jobUltimateEffectDrain": "4h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "primeval-witch": {
-            "jobId": "100-primeval-witch",
+        {
+            "_id": "100-primeval-witch",
             "jobQueryString": "primeval-witch",
             "jobType": "Meia",
             "jobName": "Primeval Witch",
@@ -2210,8 +2210,8 @@
             "jobUltimateEffectUnguard": "2h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "judge-magister-[hof]": {
-            "jobId": "101-judge-magister-[hof]",
+        {
+            "_id": "101-judge-magister-[hof]",
             "jobQueryString": "judge-magister-[hof]",
             "jobType": "Ranger",
             "jobName": "Judge Magister [HoF]",
@@ -2250,8 +2250,8 @@
             "jobUltimateEffectSnipe": "4h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "prima-donna": {
-            "jobId": "102-prima-donna",
+        {
+            "_id": "102-prima-donna",
             "jobQueryString": "prima-donna",
             "jobType": "Sarah",
             "jobName": "Prima Donna",
@@ -2291,8 +2291,8 @@
             "jobUltimateEffectTrance": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "beach-queen": {
-            "jobId": "103-beach-queen",
+        {
+            "_id": "103-beach-queen",
             "jobQueryString": "beach-queen",
             "jobType": "Sarah",
             "jobName": "Beach Queen",
@@ -2333,8 +2333,8 @@
             "jobUltimateEffectTrance": "x",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "deep-diver": {
-            "jobId": "104-deep-diver",
+        {
+            "_id": "104-deep-diver",
             "jobQueryString": "deep-diver",
             "jobType": "Monk",
             "jobName": "Deep Diver",
@@ -2378,8 +2378,8 @@
             "jobUltimateEffectTrance": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
-        "mellow-mermaid": {
-            "jobId": "105-mellow-mermaid",
+        {
+            "_id": "105-mellow-mermaid",
             "jobQueryString": "mellow-mermaid",
             "jobType": "Meia",
             "jobName": "Mellow Mermaid",
@@ -2424,8 +2424,8 @@
             "jobUltimateEffectWall": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "tidus": {
-            "jobId": "106-tidus",
+        {
+            "_id": "106-tidus",
             "jobQueryString": "tidus",
             "jobType": "Ranger",
             "jobName": "Tidus",
@@ -2447,8 +2447,8 @@
             "jobUltimateEffectTranceIi": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "legendary-guardian": {
-            "jobId": "107-legendary-guardian",
+        {
+            "_id": "107-legendary-guardian",
             "jobQueryString": "legendary-guardian",
             "jobType": "Warrior",
             "jobName": "Legendary Guardian",
@@ -2495,8 +2495,8 @@
             "jobUltimateEffectTrance": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "ascetic-(atk)": {
-            "jobId": "108-ascetic-(atk)",
+        {
+            "_id": "108-ascetic-(atk)",
             "jobQueryString": "ascetic-(atk)",
             "jobType": "Monk",
             "jobName": "Ascetic (ATK)",
@@ -2541,8 +2541,8 @@
             "jobUltimateEffectWeaken": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
-        "ascetic-(def)": {
-            "jobId": "109-ascetic-(def)",
+        {
+            "_id": "109-ascetic-(def)",
             "jobQueryString": "ascetic-(def)",
             "jobType": "Monk",
             "jobName": "Ascetic (DEF)",
@@ -2587,8 +2587,8 @@
             "jobUltimateEffectWeaken": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
-        "proud-cygnus": {
-            "jobId": "110-proud-cygnus",
+        {
+            "_id": "110-proud-cygnus",
             "jobQueryString": "proud-cygnus",
             "jobType": "Sarah",
             "jobName": "Proud Cygnus",
@@ -2629,8 +2629,8 @@
             "jobUltimateEffectTrance": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "al-bhed-huntress": {
-            "jobId": "111-al-bhed-huntress",
+        {
+            "_id": "111-al-bhed-huntress",
             "jobQueryString": "al-bhed-huntress",
             "jobType": "Sarah",
             "jobName": "Al-Bhed Huntress",
@@ -2672,8 +2672,8 @@
             "jobUltimateEffectWeaken": "2h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "vana'diel-geomancer": {
-            "jobId": "112-vana'diel-geomancer",
+        {
+            "_id": "112-vana'diel-geomancer",
             "jobQueryString": "vana'diel-geomancer",
             "jobType": "Meia",
             "jobName": "Vana'diel Geomancer",
@@ -2723,8 +2723,8 @@
             "jobUltimateEffectTrance": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "vana'diel-monk": {
-            "jobId": "113-vana'diel-monk",
+        {
+            "_id": "113-vana'diel-monk",
             "jobQueryString": "vana'diel-monk",
             "jobType": "Monk",
             "jobName": "Vana'diel Monk",
@@ -2769,8 +2769,8 @@
             "jobUltimateEffectTrance": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
-        "shorn-one": {
-            "jobId": "114-shorn-one",
+        {
+            "_id": "114-shorn-one",
             "jobQueryString": "shorn-one",
             "jobType": "Warrior",
             "jobName": "Shorn One",
@@ -2814,8 +2814,8 @@
             "jobUltimateEffectUnguard": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "skyseer": {
-            "jobId": "115-skyseer",
+        {
+            "_id": "115-skyseer",
             "jobQueryString": "skyseer",
             "jobType": "Mage",
             "jobName": "Skyseer",
@@ -2859,8 +2859,8 @@
             "jobUltimateEffectTrance": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "gambler": {
-            "jobId": "116-gambler",
+        {
+            "_id": "116-gambler",
             "jobQueryString": "gambler",
             "jobType": "Ranger",
             "jobName": "Gambler",
@@ -2905,8 +2905,8 @@
             "jobUltimateEffectTrance": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "night-walker": {
-            "jobId": "117-night-walker",
+        {
+            "_id": "117-night-walker",
             "jobQueryString": "night-walker",
             "jobType": "Meia",
             "jobName": "Night Walker",
@@ -2948,8 +2948,8 @@
             "jobUltimateEffectWeaken": "2h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "materia-hunter": {
-            "jobId": "118-materia-hunter",
+        {
+            "_id": "118-materia-hunter",
             "jobQueryString": "materia-hunter",
             "jobType": "Sarah",
             "jobName": "Materia Hunter",
@@ -2993,8 +2993,8 @@
             "jobUltimateEffectTrance": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "agent-of-scarlet-woe": {
-            "jobId": "119-agent-of-scarlet-woe",
+        {
+            "_id": "119-agent-of-scarlet-woe",
             "jobQueryString": "agent-of-scarlet-woe",
             "jobType": "Monk",
             "jobName": "Agent Of Scarlet Woe",
@@ -3038,8 +3038,8 @@
             "jobUltimateEffectTrance": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
-        "tifa": {
-            "jobId": "120-tifa",
+        {
+            "_id": "120-tifa",
             "jobQueryString": "tifa",
             "jobType": "Ranger",
             "jobName": "Tifa",
@@ -3060,8 +3060,8 @@
             "jobUltimateEffectTranceIi": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "dawn-warrior": {
-            "jobId": "121-dawn-warrior",
+        {
+            "_id": "121-dawn-warrior",
             "jobQueryString": "dawn-warrior",
             "jobType": "Warrior",
             "jobName": "Dawn Warrior",
@@ -3081,8 +3081,8 @@
             "jobUltimateEffectTranceIi": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "wild-rider": {
-            "jobId": "122-wild-rider",
+        {
+            "_id": "122-wild-rider",
             "jobQueryString": "wild-rider",
             "jobType": "Sophie",
             "jobName": "Wild Rider",
@@ -3120,8 +3120,8 @@
             "jobUltimateEffectWall": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
-        "hermit-[hof]": {
-            "jobId": "123-hermit-[hof]",
+        {
+            "_id": "123-hermit-[hof]",
             "jobQueryString": "hermit-[hof]",
             "jobType": "Monk",
             "jobName": "Hermit [HoF]",
@@ -3165,8 +3165,8 @@
             "jobUltimateEffectSlow": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
-        "jet-stunner": {
-            "jobId": "124-jet-stunner",
+        {
+            "_id": "124-jet-stunner",
             "jobQueryString": "jet-stunner",
             "jobType": "Sophie",
             "jobName": "Jet Stunner",
@@ -3210,8 +3210,8 @@
             "jobUltimateEffectWall": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
-        "magitek-jester": {
-            "jobId": "125-magitek-jester",
+        {
+            "_id": "125-magitek-jester",
             "jobQueryString": "magitek-jester",
             "jobType": "Mage",
             "jobName": "Magitek Jester",
@@ -3258,8 +3258,8 @@
             "jobUltimateEffectWeaken": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "magitek-heroine": {
-            "jobId": "126-magitek-heroine",
+        {
+            "_id": "126-magitek-heroine",
             "jobQueryString": "magitek-heroine",
             "jobType": "Sarah",
             "jobName": "Magitek Heroine",
@@ -3303,8 +3303,8 @@
             "jobUltimateEffectTrance": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "balamb-mercenary-[hof]": {
-            "jobId": "127-balamb-mercenary-[hof]",
+        {
+            "_id": "127-balamb-mercenary-[hof]",
             "jobQueryString": "balamb-mercenary-[hof]",
             "jobType": "Warrior",
             "jobName": "Balamb Mercenary [HoF]",
@@ -3345,8 +3345,8 @@
             "jobUltimateEffectTrance": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "tonberry-suit-[hof]": {
-            "jobId": "128-tonberry-suit-[hof]",
+        {
+            "_id": "128-tonberry-suit-[hof]",
             "jobQueryString": "tonberry-suit-[hof]",
             "jobType": "Mage",
             "jobName": "Tonberry Suit [HoF]",
@@ -3385,8 +3385,8 @@
             "jobUltimateEffectWeaken": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "thief-of-tantalus-[hof]": {
-            "jobId": "129-thief-of-tantalus-[hof]",
+        {
+            "_id": "129-thief-of-tantalus-[hof]",
             "jobQueryString": "thief-of-tantalus-[hof]",
             "jobType": "Ranger",
             "jobName": "Thief of Tantalus [Hof]",
@@ -3426,8 +3426,8 @@
             "jobUltimateEffectTrance": "x",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "moogle-suit-[hof]": {
-            "jobId": "130-moogle-suit-[hof]",
+        {
+            "_id": "130-moogle-suit-[hof]",
             "jobQueryString": "moogle-suit-[hof]",
             "jobType": "Monk",
             "jobName": "Moogle Suit [HoF]",
@@ -3464,8 +3464,8 @@
             "jobUltimateEffectDebarrier": "x",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
-        "gardien": {
-            "jobId": "131-gardien",
+        {
+            "_id": "131-gardien",
             "jobQueryString": "gardien",
             "jobType": "Graff",
             "jobName": "Gardien",
@@ -3505,8 +3505,8 @@
             "jobUltimateEffectUnguard": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "toredor": {
-            "jobId": "132-toredor",
+        {
+            "_id": "132-toredor",
             "jobQueryString": "toredor",
             "jobType": "Graff",
             "jobName": "Toredor",
@@ -3550,8 +3550,8 @@
             "jobUltimateEffectWeaken": "2h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "gilgamesh": {
-            "jobId": "133-gilgamesh",
+        {
+            "_id": "133-gilgamesh",
             "jobQueryString": "gilgamesh",
             "jobType": "Ranger",
             "jobName": "Gilgamesh",
@@ -3572,8 +3572,8 @@
             "jobUltimateEffectTranceIi": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "cacciatrice": {
-            "jobId": "134-cacciatrice",
+        {
+            "_id": "134-cacciatrice",
             "jobQueryString": "cacciatrice",
             "jobType": "Sarah",
             "jobName": "Cacciatrice",
@@ -3621,8 +3621,8 @@
             "jobUltimateEffectTrance": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "stranger-to-the-mythos": {
-            "jobId": "135-stranger-to-the-mythos",
+        {
+            "_id": "135-stranger-to-the-mythos",
             "jobQueryString": "stranger-to-the-mythos",
             "jobType": "Sophie",
             "jobName": "Stranger to the Mythos",
@@ -3668,8 +3668,8 @@
             "jobUltimateEffectWeaken": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
-        "paradox-wanderer": {
-            "jobId": "136-paradox-wanderer",
+        {
+            "_id": "136-paradox-wanderer",
             "jobQueryString": "paradox-wanderer",
             "jobType": "Sarah",
             "jobName": "Paradox Wanderer",
@@ -3717,8 +3717,8 @@
             "jobUltimateEffectWall": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "scharfrichter-(atk)": {
-            "jobId": "137-scharfrichter-(atk)",
+        {
+            "_id": "137-scharfrichter-(atk)",
             "jobQueryString": "scharfrichter-(atk)",
             "jobType": "Warrior",
             "jobName": "Scharfrichter (ATK)",
@@ -3775,8 +3775,8 @@
             "jobUltimateEffectTranceIi": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "scharfrichter-(def)": {
-            "jobId": "138-scharfrichter-(def)",
+        {
+            "_id": "138-scharfrichter-(def)",
             "jobQueryString": "scharfrichter-(def)",
             "jobType": "Warrior",
             "jobName": "Scharfrichter (DEF)",
@@ -3833,8 +3833,8 @@
             "jobUltimateEffectTranceIi": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "esmeralda-[hof]": {
-            "jobId": "139-esmeralda-[hof]",
+        {
+            "_id": "139-esmeralda-[hof]",
             "jobQueryString": "esmeralda-[hof]",
             "jobType": "Meia",
             "jobName": "Esmeralda [HoF]",
@@ -3875,8 +3875,8 @@
             "jobUltimateEffectSnipe": "4h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "fauviste-[hof]": {
-            "jobId": "140-fauviste-[hof]",
+        {
+            "_id": "140-fauviste-[hof]",
             "jobQueryString": "fauviste-[hof]",
             "jobType": "Meia",
             "jobName": "Fauviste [HoF]",
@@ -3916,8 +3916,8 @@
             "jobUltimateEffectQuicken": 4,
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "amalthea-[hof]": {
-            "jobId": "141-amalthea-[hof]",
+        {
+            "_id": "141-amalthea-[hof]",
             "jobQueryString": "amalthea-[hof]",
             "jobType": "Meia",
             "jobName": "Amalthea [HoF]",
@@ -3961,8 +3961,8 @@
             "jobUltimateEffectWall": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "kampfer-(atk)": {
-            "jobId": "142-kampfer-(atk)",
+        {
+            "_id": "142-kampfer-(atk)",
             "jobQueryString": "kampfer-(atk)",
             "jobType": "Monk",
             "jobName": "Kampfer (ATK)",
@@ -4020,8 +4020,8 @@
             "jobUltimateEffectWall": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
-        "kampfer-(def)": {
-            "jobId": "143-kampfer-(def)",
+        {
+            "_id": "143-kampfer-(def)",
             "jobQueryString": "kampfer-(def)",
             "jobType": "Monk",
             "jobName": "Kampfer (DEF)",
@@ -4078,110 +4078,110 @@
             "jobUltimateEffectWall": "3h",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
-        "tropical-traveler": {
-            "jobId": "144-tropical-traveler",
+        {
+            "_id": "144-tropical-traveler",
             "jobQueryString": "tropical-traveler",
             "jobType": "Sophie",
             "jobName": "Tropical Traveler",
             "jobIsLegend": "x",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/6.png"
         },
-        "sword-saint-(atk)-[hof]": {
-            "jobId": "145-sword-saint-(atk)-[hof]",
+        {
+            "_id": "145-sword-saint-(atk)-[hof]",
             "jobQueryString": "sword-saint-(atk)-[hof]",
             "jobType": "Warrior",
             "jobName": "Sword Saint (ATK) [HoF]",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "sword-saint-(def)-[hof]": {
-            "jobId": "146-sword-saint-(def)-[hof]",
+        {
+            "_id": "146-sword-saint-(def)-[hof]",
             "jobQueryString": "sword-saint-(def)-[hof]",
             "jobType": "Warrior",
             "jobName": "Sword Saint (DEF) [HoF]",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "sage-[hof]": {
-            "jobId": "147-sage-[hof]",
+        {
+            "_id": "147-sage-[hof]",
             "jobQueryString": "sage-[hof]",
             "jobType": "Mage",
             "jobName": "Sage [HoF]",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "vagabond": {
-            "jobId": "148-vagabond",
+        {
+            "_id": "148-vagabond",
             "jobQueryString": "vagabond",
             "jobType": "Graff",
             "jobName": "Vagabond",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "ninja-[hof]": {
-            "jobId": "149-ninja-[hof]",
+        {
+            "_id": "149-ninja-[hof]",
             "jobQueryString": "ninja-[hof]",
             "jobType": "Ranger",
             "jobName": "Ninja [HoF]",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "sorceress's-knight": {
-            "jobId": "150-sorceress's-knight",
+        {
+            "_id": "150-sorceress's-knight",
             "jobQueryString": "sorceress's-knight",
             "jobType": "Graff",
             "jobName": "Sorceress's Knight",
             "jobIsLegend": "x",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "squall-leonhart": {
-            "jobId": "151-squall-leonhart",
+        {
+            "_id": "151-squall-leonhart",
             "jobQueryString": "squall-leonhart",
             "jobType": "Warrior",
             "jobName": "Squall Leonhart",
             "jobIsSkin": "x",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "squall": {
-            "jobId": "152-squall",
+        {
+            "_id": "152-squall",
             "jobQueryString": "squall",
             "jobType": "Warrior",
             "jobName": "Squall",
             "jobIsSkin": "x",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/1.png"
         },
-        "sorceress-of-oblivion": {
-            "jobId": "153-sorceress-of-oblivion",
+        {
+            "_id": "153-sorceress-of-oblivion",
             "jobQueryString": "sorceress-of-oblivion",
             "jobType": "Meia",
             "jobName": "Sorceress of Oblivion",
             "jobIsLegend": "x",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "reisender": {
-            "jobId": "154-reisender",
+        {
+            "_id": "154-reisender",
             "jobQueryString": "reisender",
             "jobType": "Ranger",
             "jobName": "Reisender",
             "jobIsEx": "x",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/3.png"
         },
-        "glam-vamp-[hof]": {
-            "jobId": "155-glam-vamp-[hof]",
+        {
+            "_id": "155-glam-vamp-[hof]",
             "jobQueryString": "glam-vamp-[hof]",
             "jobType": "Meia",
             "jobName": "Glam Vamp [HoF]",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "vesna-krasna-[hof]": {
-            "jobId": "156-vesna-krasna-[hof]",
+        {
+            "_id": "156-vesna-krasna-[hof]",
             "jobQueryString": "vesna-krasna-[hof]",
             "jobType": "Meia",
             "jobName": "Vesna Krasna [HoF]",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         },
-        "wahrsager": {
-            "jobId": "157-wahrsager",
+        {
+            "_id": "157-wahrsager",
             "jobQueryString": "wahrsager",
             "jobType": "Mage",
             "jobName": "Wahrsager",
             "jobIsEx": "x",
             "jobUrlIcon": "https://img.altema.jp/ffmobius/jobtype/2.png"
         }
-    }
+    ]
 ]

--- a/src/models/jobs.model.js
+++ b/src/models/jobs.model.js
@@ -1,0 +1,28 @@
+const mongoose = require('mongoose');
+
+const Schema = mongoose.Schema;
+
+const jobSchema = new Schema({
+    jobId: { type: String, required: true, unique: true},
+    jobQueryString: { type: String, required: true },
+    jobType: { type: String, required: true },
+    jobName: { type: String, required: true },
+    jobStat: {
+        Hp: { type: Number, required: true },
+        Attack: { type: Number, required: true },
+        Break: { type: Number, required: true },
+        Magic: { type: Number, required: true },
+        CritChance: { type: Number, required: true },
+        Speed: { type: Number, required: true },
+        Defense: { type: Number, required: true }
+    },
+    jobOrbs: Schema.Types.Mixed, // multiple orbsets
+    jobMpRole: { type: String, required: true },
+    jobUrlIcon: { type: String, required: true }
+}, {
+    timestamps: true
+});
+
+const Job = mongoose.model('Job', jobSchema);
+
+module.exports = Job;

--- a/src/models/jobs.model.js
+++ b/src/models/jobs.model.js
@@ -3,24 +3,24 @@ const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
 const jobSchema = new Schema({
-    jobId: { type: String, required: true, unique: true},
-    jobQueryString: { type: String, required: true },
-    jobType: { type: String, required: true },
-    jobName: { type: String, required: true },
-    jobStat: {
-        Hp: { type: Number, required: true },
-        Attack: { type: Number, required: true },
-        Break: { type: Number, required: true },
-        Magic: { type: Number, required: true },
-        CritChance: { type: Number, required: true },
-        Speed: { type: Number, required: true },
-        Defense: { type: Number, required: true }
-    },
-    jobOrbs: Schema.Types.Mixed, // multiple orbsets
-    jobMpRole: { type: String, required: true },
-    jobUrlIcon: { type: String, required: true }
-}, {
-    timestamps: true
+//     jobId: { type: String, required: true, unique: true},
+//     jobQueryString: { type: String, required: true },
+//     jobType: { type: String, required: true },
+//     jobName: { type: String, required: true },
+//     jobStat: {
+//         Hp: { type: Number, required: true },
+//         Attack: { type: Number, required: true },
+//         Break: { type: Number, required: true },
+//         Magic: { type: Number, required: true },
+//         CritChance: { type: Number, required: true },
+//         Speed: { type: Number, required: true },
+//         Defense: { type: Number, required: true }
+//     },
+//     jobOrbs: Schema.Types.Mixed, // multiple orbsets
+//     jobMpRole: { type: String, required: true },
+//     jobUrlIcon: { type: String, required: true }
+// }, {
+//     timestamps: true
 });
 
 const Job = mongoose.model('Job', jobSchema);


### PR DESCRIPTION
MongoDB hosted using MongoDB atlas

Collection is deleted on application start then re-added since `yarn dbfetch` is the only way to update db at the moment

Todo (maybe):

- Define proper classes for data to be stored instead of raw json exported from gdocs

- Implement better solution to update current collection